### PR TITLE
Update from online website

### DIFF
--- a/dreamcli/index.html
+++ b/dreamcli/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>DreamCLI Wrapper</title>
+  <title>DreamDNS Dynamic DNS Updater</title>
   <style type="text/css">
     body {
       margin: 0px;
@@ -45,78 +45,103 @@
 
 
 <body><div id="info">
-  <h2>DreamCLI (DreamHost API CLI Wrapper)</h2>
+  <h2>DreamDNS Updater</h2>
   <div class="blurb">
     <h3>Purpose</h3>
     <div class="description">
-      This script was made as a wrapper to the DreamHost API, so that it can easily be used on the
-      command line, or by other scripts.
+      This script was made to keep dns records available for my home network (<a href="http://en.wikipedia.org/wiki/Dynamic_DNS">Dynamic DNS</a>).
       <br><br>
       Oh, and the <a href="http://blog.dreamhost.com/2009/04/09/big-boy-time/">DreamHost API contest</a>
     </div>
   </div>
-  
+
+<div class="blurb">
+    <h3>Download</h3>
+    <div class="description">
+	2018-02-16 version 0.4 is available
+	    <br><a href="https://github.com/jhlange/dreamapi/tree/master/dreamdns">view on github</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/jhlange/dreamapi/archive/master.zip">(direct download)</a>
+    </div>
+  </div>
+	
   <div class="blurb">
     <h3>Why?</h3>
     <div class="description">
-      Because web scripting can be annoying. Especially for those of us who are used to BASH or other types of
-      scripting. Or, maybe we just perfer the command line?
+      I've been using dyndns.org for several years now. Well, it does work, but there are several problems
+      with it. Mainly the free version has many limitations:
+      <ul>
+        <li>You can only track 5 hosts (even if you pay $10/year, as I do, this is still capped to some number)</li>
+        <li>Hostnames randomly get deleted (If you don't update them for long enough, your names go away!)</li>
+        <li>If you forget to pay your dues (for the paid service), all but 5 of your domains get instantly deleted</li>
+        <li>It's not a domain I control; I've been forced, up until now, to make a CNAME from my DreamHost domain to a dyndns domain</li>
+      </ul>
     </div>
   </div>
   
   <div class="blurb">
     <h3>How it works</h3>
     <div class="description">
-      Simple, it takes all the options you set in the confuration, and all your command line options,
-      and it sends them over to dreamhost. The result is printed (tab format). The error code is returned
-      as an error code, like CLI programs usually do, and any extra error information is printed to STDERR,
-      so that it doesn't get in the way of a script thats trying to use the command output.
-      <br><br>
-      Some of the features to help your scripting/use:
+      This first thing the script does is determine your IP. There are several ways to do this, and the script
+      supports supports a few of them:
       <ul>
-        <li>If you forget the dreamhost commands, simply omit --cmd, and you will be given your accessable commands</li>
-        <li>You can specify --noheader, so that the column names get stripped out</li>
-        <li>You can specify --cols col1,col2,colN... to print out only the columns you want, in the order you want</li>
+        <li>Use a web service (*DEFAULT*)</li>
+	<ul>
+	  <li>Defaults to a service I set up</li>
+	  <li>Usually the most accurate, works behind NAT</li>
+	  <li>Can use *ANY* ip web service, even html ones, as long as perl's UA isn't blocked</li>
+	</ul>
+	<li>Track a network card's IP</li>
+	<ul>
+	  <li>This works well on local networks</li>
+	  <li>Use "windows" as your network card in Windows</li>
+	</ul>
+	<li>Manually specify an IP to use</li>
+	<ul>
+	  <li>try using in conjunction with the --once option</li>
+	  <li>Works well if you have another script deciding what to update</li>
+	  <li>e.g. ./dreamdns.pl --once --domain homerouter1.mydomain.com --ip 127.0.0.1</li>
+	</ul>
       </ul>
-      Examples? Sure.
-      <ul>
-        <li>./dreamcli.pl --help</li>
-        <li>./dreamcli.pl --cmd domain-list_domains --cols domain --noheaders  #prints out all your domain names</li>
-        <li>./dreamcli.pl --cmd domain-list_domains  #prints out everything</li>
-        <li>./dreamcli.pl --cmd announcement_list-list_subscribers --listname list1 --domain joshlange.net --cols email,name</li>
-      </ul>
-      Can I change things? Of course...
-      <ul>
-        <li>./dreamcli.pl --cmd dns-add_record --record mycomputer.mydomain.com --type A --value 4.2.2.2</li>
-      </ul> 
+      Then, the script begins looping, and updating dns for your domain as necessary (unless you specify --once).
     </div>
   </div>
   
   <div class="blurb">
     <h3>Supported Platforms</h3>
     <div class="description">
-      I personally use several different platforms, and I know how imporant it is to support them all. Any platform
-      that supports perl is supported by this script.
+      I personally use several different platforms, and I know how imporant it is to support them all.
+      <ul>
+        <li>This script should work on any modern OS platform supporting perl.</li>
+	<li>Unfortunately, the --nic option requires you to run a "supported" platform. They are currently:</li>
+	<ul>
+	  <li>Most, if not all, Linux distros</li>
+	  <li>MacOS</li>
+	  <li>Solaris</li>
+	  <li>BSD</li>
+	  <li>Others.....(with BSD style ifconfig)</li>
+	  <li>...And Windows <b>(but, you should use  <a href="https://github.com/mattgwagner/Dreamhost-Dynamic-DNS-Updater">this</a> instead)</b></li>
+	</ul>
+      </ul>
     </div>
   </div>
   
   <div class="blurb">
     <h3>Getting Started</h3>
     <div class="description">
-      The easiest way to get started with DreamCLI is to download it, and run it on the command line.
+      The easiest way to get started with DreamDNS is to download it, and run it on the command line.
       <ul>
         <li>Install perl from your operating system's package manager, if you don't already have perl</li>
         <li>If you are using windows, install <a href="http://www.activestate.com/activeperl/">ActivePerl</a> for Windows</li>
         <li>If you get a "bad interperter" error, put the correct path to perl on line 1 of the script</li>
+        <li><b>NOTE: Windows users, you should probably be using this <a href="https://github.com/mattgwagner/Dreamhost-Dynamic-DNS-Updater">Windows alternative</a></b></li>
       </ul>
-      <div align="center"><img src="dreamcli.png"></img></div>
+      <div align="center"><img src="dreamdns.png"></img></div>
     </div>
   </div>
 
   <div class="blurb">
-    <h3>Setup</h3>
+    <h3>Daemon/Service setup</h3>
     <div class="description">
-      The setup is very straight forward.
+      Yes! It's possible! It's easy!
       <ol>
         <li>Install perl</li>
 	<ul>
@@ -125,17 +150,35 @@
 	</ul>
         <li><a href="https://panel.dreamhost.com/?tree=home.api">Generate an API key</a></li>
 	<ul>
-	  <li>Make sure that anything you want is checked</li>
+	  <li>Make sure that dns-* is checked</li>
 	  <li>Uncheck everything else</li>
 	</ul>
-        <li>Edit configuration (so you don't need to give cli arguements, optional)</li>
+        <li>Edit configuration (so you don't need to give cli arguements)</li>
 	<ul>
-	  <li>In a text editor, put your api key, username, and domain into the script where indicated.</li>
+	  <li>In a text editor, put your api key and domain into the script where indicated.</li>
 	</ul>
         <li>Test out the script</li>
 	<ul>
-	  <li>Open a terminal, and run the script</li>
-	  <li>View the available dreamhost api commands with options here: <a href="http://wiki.dreamhost.com/Application_programming_interface#List_of_API_Modules">http://wiki.dreamhost.com/Application_programming_interface#List_of_API_Modules</a></li>
+	  <li>Open a terminal, and run the script without any cli options, other then: --verbosity 5</li>
+	</ul>
+        <li>Make your OS run it at boot!</li>
+	<ul>
+	  <li>Linux</li>
+	  <ul>
+	    <li>Add "su  username  -c '/path/to/script/dreamdns.pl --daemon' " to your /etc/rc.local or /etc/init.d/rc.local</li>
+	    <li>replace username with a valid unprivileged non-root username</li>
+	    <li>NOTE: Your system may stall on boot if you don't give the "--daemon" option</li>
+	  </ul>
+	  <li>Windows</li>
+	  <ul>
+	    <li>Consult <a href="http://support.microsoft.com/kb/251192">http://support.microsoft.com/kb/251192</a> about adding a service</li>
+	    <li>You probably SHOULD NOT use the "--daemon" option with windows, so that windows can properly monitor the service</li>
+	  </ul>
+	  <li>Others</li>
+	  <ul>
+	    <li>Consult proper documentation</li>
+	    <li>launch with the "--daemon" option, or set daemonize = 1 in the script's config</li>
+	  </ul>
 	</ul>
       </ol>
     </div>
@@ -168,29 +211,11 @@ RULES FOR MODIFICATIONS
     <h3>Contest specifics</h3>
     <div class="description">
     I saw another submission had this, so I am adding it.
-      <li>Submitted: May 3rd, 2009</li>
-      <li>Application Name: DreamCLI Wrapper</li>
-      <li>API Functions Used: all</li>
+      <li>Submitted: May 2nd, 2009</li>
+      <li>Application Name: DreamDNS Updater</li>
+      <li>API Functions Used: dns-*</li>
     </div>
   </div>
 
-  <div class="blurb">
-    <h3>Download</h3>
-    <div class="description">
-      05-04-09 v0.2 is now available
-      <ul>
-        <li>You can now specify to only print certain columns with --cols</li>
-        <li>--nocols option renamed to --noheaders</li>
-      </ul>
-      <br><a href="https://github.com/jhlange/dreamapi/tree/master/dreamcli">view on github</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/jhlange/dreamapi/archive/master.zip">(direct download)</a>
-    </div>
-  </div>
-  
-  <div class="blurb">
-    <h3></h3>
-    <div class="description">
-    </div>
-  </div>
-  
 </div></body>
 </html>


### PR DESCRIPTION
The source in github is outdated. This version is from the current online website, with the following changes:
- indicate latest version available (0.4) and date.
- couldn't find date for version 0.3 so I removed its dated entry
- moved Download section to the top

NOTE: I didn't test the image, it seems to have changed.